### PR TITLE
Rename column id_type_siege to id_place in script.sql

### DIFF
--- a/database/script.sql
+++ b/database/script.sql
@@ -55,10 +55,10 @@ CREATE TABLE place_vol (
     id SERIAL,
     prix DOUBLE PRECISION,
     id_vol INTEGER NOT NULL,
-    id_type_siege INTEGER NOT NULL,
+    id_place INTEGER NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (id_vol) REFERENCES vol (id),
-    FOREIGN KEY (id_type_siege) REFERENCES type_siege (id)
+    FOREIGN KEY (id_place) REFERENCES place (id)
 );
 CREATE TABLE promotion (
     id SERIAL,


### PR DESCRIPTION
This pull request includes a change to the `database/script.sql` file to update the schema of the `place_vol` table. The change modifies the foreign key reference from `type_siege` to `place`.

Schema update:

* [`database/script.sql`](diffhunk://#diff-18c64f565030282138f252b6f318c3d0696ab340854867dc93ce7e6fa2da8443L58-R61): Changed the column `id_type_siege` to `id_place` and updated the foreign key reference accordingly in the `place_vol` table.